### PR TITLE
Update build & release

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch all history for all tags and branches
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/build.sh
+++ b/build.sh
@@ -2,56 +2,14 @@
 
 set -e
 
-# Function to get the latest tag from GitHub
-get_latest_tag() {
-    git fetch --tags
-    git describe --tags --abbrev=0
-}
-
-# Function to increment minor version
-increment_minor_version() {
-    local version=$1
-    local major=$(echo "$version" | cut -d. -f1)
-    local minor=$(echo "$version" | cut -d. -f2)
-    local patch=$(echo "$version" | cut -d. -f3)
-    
-    new_minor=$((minor + 1))
-    echo "${major}.${new_minor}.0-dev"
-}
-
-# Check if --dev flag is passed
-if [[ "$1" == "--dev" ]]; then
-    DEV_BUILD=true
-    shift
-else
-    DEV_BUILD=false
-fi
-
-# Determine the version
-LATEST_TAG=$(get_latest_tag)
-if [ "$DEV_BUILD" = true ]; then
-    VERSION=$(increment_minor_version "$LATEST_TAG")
-else
-    VERSION=$LATEST_TAG
-fi
-
-# Remove 'v' prefix if present
-VERSION=${VERSION#v}
-
-# Update CurrentCliVersion in vars.go
-sed -i '' "s/const CurrentCliVersion = .*/const CurrentCliVersion = \"$VERSION\"/" src/common/vars.go
-
 # Set binary name
 BINARY_NAME="ploy"
 
 # Determine the build number (use the GitHub run number if available, otherwise set to 0)
 BUILD_NUMBER=${GITHUB_RUN_NUMBER:-0}
 
-# Get the server type from the first argument, default to "standard" if not provided
-SERVER_TYPE=${1:-standard}
-
 # Set the ldflags
-LDFLAGS="-X 'github.com/ploycloud/ploy-server-cli/cmd.Version=${VERSION}' -X 'github.com/ploycloud/ploy-server-cli/cmd.BuildNumber=${BUILD_NUMBER}' -X 'github.com/ploycloud/ploy-server-cli/cmd.ServerType=${SERVER_TYPE}'"
+LDFLAGS="-X 'github.com/ploycloud/ploy-server-cli/cmd.BuildNumber=${BUILD_NUMBER}'"
 
 # Create or recreate the build folder
 BUILD_DIR="build"
@@ -62,12 +20,12 @@ mkdir -p "$BUILD_DIR"
 build() {
     local os=$1
     local arch=$2
-    local output="${BUILD_DIR}/${BINARY_NAME}-${SERVER_TYPE}-${os}-${arch}"
+    local output="${BUILD_DIR}/${BINARY_NAME}-${os}-${arch}"
     if [ "$os" = "windows" ]; then
         output="${output}.exe"
     fi
 
-    echo "Building ${SERVER_TYPE} version ${VERSION} for ${os}/${arch}..."
+    echo "Building for ${os}/${arch}..."
     if ! GOOS=$os GOARCH=$arch go build -ldflags "${LDFLAGS}" -o "${output}" .; then
         echo "Failed to build for ${os}/${arch}"
         exit 1
@@ -93,12 +51,12 @@ build darwin arm64
 # Generate checksums
 cd "$BUILD_DIR"
 if command -v sha256sum > /dev/null; then
-    sha256sum ${BINARY_NAME}-"${SERVER_TYPE}"-*.tar.gz > checksums-"${SERVER_TYPE}".txt
+    sha256sum ${BINARY_NAME}-*.tar.gz > checksums.txt
 elif command -v shasum > /dev/null; then
-    shasum -a 256 ${BINARY_NAME}-"${SERVER_TYPE}"-*.tar.gz > checksums-"${SERVER_TYPE}".txt
+    shasum -a 256 ${BINARY_NAME}-*.tar.gz > checksums.txt
 else
     echo "Neither sha256sum nor shasum command found. Skipping checksum generation."
 fi
 cd ..
 
-echo "Build completed successfully for ${SERVER_TYPE} server version ${VERSION}. Artifacts are in the '$BUILD_DIR' directory."
+echo "Build completed successfully. Artifacts are in the '$BUILD_DIR' directory."

--- a/src/common/vars.go
+++ b/src/common/vars.go
@@ -1,6 +1,6 @@
 package common
 
-const CurrentCliVersion = "0.3.0"
+const CurrentCliVersion = "0.4.0"
 
 const HomeDir = "/home/ploy"
 const ServicesDir = HomeDir + "/.ploy"


### PR DESCRIPTION
This pull request includes significant changes to the build process and versioning system, along with a minor update to the GitHub workflow configuration. The most important changes streamline the build script by removing unnecessary functions and parameters, and update the CLI version.

### Build Script Simplification:

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L5-R12): Removed functions for fetching the latest tag and incrementing the minor version, as well as logic for handling development builds. Simplified the `LDFLAGS` variable by removing the `ServerType` and `Version` parameters.
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L65-R28): Updated the output binary naming convention to exclude the `ServerType` and modified the build message to remove the version and server type.
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L96-R62): Simplified checksum generation by removing the `ServerType` from the checksum file names and the final build completion message.

### Version Update:

* [`src/common/vars.go`](diffhunk://#diff-225ac9a325f155775e2e9d879bb9fd82d2398db327467cb9ff7808b2f86e6717L3-R3): Updated the `CurrentCliVersion` constant from `0.3.0` to `0.4.0`.

### Workflow Configuration:

* [`.github/workflows/build-and-release.yaml`](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44R16-R17): Added `fetch-depth: 0` to the `actions/checkout@v3` step to fetch all history for all tags and branches.