### PR TITLE
Fix installer link

### DIFF
--- a/scripts/ec2-userdata.sh
+++ b/scripts/ec2-userdata.sh
@@ -79,7 +79,7 @@ fi
 
 # Install Ploy Server CLI
 log "INFO" "Installing Ploy Server CLI"
-if ! curl -fsSL https://raw.githubusercontent.com/cloudoploy/ploy-server-cli/main/install.sh | bash; then
+if ! curl -fsSL https://raw.githubusercontent.com/ploycloud/ploy-server-cli/main/install.sh | bash; then
     log "ERROR" "Failed to install Ploy Server CLI"
     exit 1
 fi


### PR DESCRIPTION
This pull request includes a small but important change to the `scripts/ec2-userdata.sh` file. The change updates the URL used to install the Ploy Server CLI.

* [`scripts/ec2-userdata.sh`](diffhunk://#diff-18612c9f07f42554bcda3b8c400f0afe06d1b63a350c4ada76d8e6e0b4864a0fL82-R82): Updated the URL for installing the Ploy Server CLI from `cloudoploy` to `ploycloud`.