### PR TITLE
Fix: Nginx proxy installer

### DIFF
--- a/scripts/ec2-userdata.sh
+++ b/scripts/ec2-userdata.sh
@@ -86,7 +86,7 @@ fi
 
 # Install Nginx Proxy using Ploy CLI
 log "INFO" "Installing Nginx Proxy using Ploy CLI"
-if ! sudo -u ploy ploy services install nginx-proxy; then
+if ! runuser -l ploy -c 'ploy services install nginx-proxy'; then
     log "ERROR" "Failed to install Nginx Proxy using Ploy CLI"
     exit 1
 fi


### PR DESCRIPTION
This pull request includes a small but important change to the `scripts/ec2-userdata.sh` file to improve the installation process of Nginx Proxy using the Ploy CLI.

* [`scripts/ec2-userdata.sh`](diffhunk://#diff-18612c9f07f42554bcda3b8c400f0afe06d1b63a350c4ada76d8e6e0b4864a0fL89-R89): Changed the user command from `sudo -u ploy` to `runuser -l ploy -c` to ensure proper execution of the Ploy CLI command.