### PR TITLE
Features/add site with db

### DIFF
--- a/src/commands/sites.go
+++ b/src/commands/sites.go
@@ -219,6 +219,11 @@ func runNewSite(cmd *cobra.Command, args []string) {
 	}
 
 	color.Green("Site launched successfully!")
+
+	// Send webhook if provided
+	if webhook != "" {
+		sendWebhook(webhook, "Site launched successfully")
+	}
 }
 
 func promptIfEmpty(value, prompt, defaultValue string) string {

--- a/src/commands/sites_test.go
+++ b/src/commands/sites_test.go
@@ -71,7 +71,7 @@ func TestLaunchSite(t *testing.T) {
 	defer func() { execCommand = oldExecCommand }()
 
 	// Test launching a site
-	err = launchSite("wp", "example.com", "external", "db.example.com", "3306", "wordpress", "user", "password", "static", 2, 0, "site123", "host.example.com", "8.3")
+	err = launchSite("wp", "example.com", "external", "db.example.com", "3306", "wordpress", "user", "password", "static", 2, 0, "site123", "host.example.com", "8.3", "")
 	assert.NoError(t, err)
 
 	// Check if the site directory was created
@@ -79,7 +79,7 @@ func TestLaunchSite(t *testing.T) {
 	assert.DirExists(t, siteDir, "Site directory should exist")
 
 	// Check if the Docker Compose file was created in the site directory
-	composePath := filepath.Join(siteDir, "docker-compose.yml")
+	composePath := filepath.Join(siteDir, "docker-compose-wp-php8.3.yml")
 	assert.FileExists(t, composePath, "Docker Compose file should exist in the site directory")
 
 	// Read the content of the Docker Compose file
@@ -91,7 +91,7 @@ func TestLaunchSite(t *testing.T) {
 
 	// Check if the Docker Compose command was executed
 	assert.Contains(t, CaptureOutput(func() {
-		launchSite("wp", "example.com", "external", "db.example.com", "3306", "wordpress", "user", "password", "static", 2, 0, "site123", "host.example.com", "8.3")
+		launchSite("wp", "example.com", "external", "db.example.com", "3306", "wordpress", "user", "password", "static", 2, 0, "site123", "host.example.com", "8.3", "")
 	}), "Mock command executed", "Docker Compose command should be executed")
 }
 

--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-const CurrentCliVersion = "0.5.0"
+const CurrentCliVersion = "0.5.1"
 
 var (
 	HomeDir       = os.Getenv("HOME")


### PR DESCRIPTION
This pull request introduces a new command to check the status of services and adds webhook notifications to various stages of the `launchSite` function. It also updates the Docker Compose file naming convention and includes necessary test adjustments.

### New Command for Service Status:

* [`src/commands/services.go`](diffhunk://#diff-d030ca5e14d858e9a7dcf0e0165849ded1079768af2007ed4758599e2e1341e7R318-R359): Added a new `statusCmd` to check the status of services like MySQL and nginx-proxy.
* [`src/commands/services.go`](diffhunk://#diff-d030ca5e14d858e9a7dcf0e0165849ded1079768af2007ed4758599e2e1341e7R41): Registered the `statusCmd` with the `ServicesCmd`.

### Webhook Notifications:

* [`src/commands/sites.go`](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdL292-R315): Updated `launchSite` to include a `webhook` parameter and added calls to `sendWebhook` at various stages, such as checking MySQL status, installing MySQL, and fetching MySQL details. [[1]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdL292-R315) [[2]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdR393-R419)
* [`src/commands/sites.go`](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdR393-R419): Added a `checkMySQLStatus` function to verify MySQL status using the new `statusCmd`.

### Docker Compose File Naming:

* [`src/commands/sites.go`](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdL361-R380): Modified the `launchSite` function to generate Docker Compose file names based on the PHP version.

### Test Adjustments:

* [`src/commands/sites_test.go`](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L74-R82): Updated tests to accommodate the new `webhook` parameter and the updated Docker Compose file naming convention. [[1]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L74-R82) [[2]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L94-R94)

### Version Bump:

* [`src/common/constants.go`](diffhunk://#diff-6a2f5d1264b6b4bf69186e61d76eef1cfff904b3089c3fccc7bcb255579470c6L8-R8): Incremented the CLI version from `0.5.0` to `0.5.1`.