### PR TITLE
Fix/site creation nginx

### DIFF
--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-const CurrentCliVersion = "0.5.4"
+const CurrentCliVersion = "0.5.5"
 
 var (
 	HomeDir       = os.Getenv("HOME")


### PR DESCRIPTION
This pull request introduces several changes to the `src/commands/sites.go` file, focusing on enhancing user checks and command executions, as well as updating related tests. The most important changes include adding a user check to ensure commands are run by the 'ploy' user, modifying command executions to use `sudo`, and updating tests to reflect these changes.

Enhancements to user checks and command executions:

* Added a function `checkPloyUser` to verify if the current user is 'ploy' and integrated this check into the `createNginxConfig` function to ensure the command is run by the 'ploy' user. [[1]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdR30-R39) [[2]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdR517-R521)
* Modified the `createNginxConfig` function to use `execSudo` for reloading nginx with `sudo` privileges.

Updates to tests:

* Updated `TestLaunchSite` to mock `execSudo` and `checkPloyUser`, and restructured the test to create necessary directories. [[1]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L70-L77) [[2]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L88-R130) [[3]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L114-R139) [[4]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L123-L149)
* Enhanced `TestCreateNginxConfig` to include test cases for both 'ploy' and non-'ploy' users, verifying correct behavior and error handling.

Version update:

* Updated `CurrentCliVersion` in `src/common/constants.go` from "0.5.4" to "0.5.5".