### PR TITLE
Fix/disable ploy user checking

### DIFF
--- a/src/commands/sites.go
+++ b/src/commands/sites.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"os/user"
-
 	"github.com/fatih/color"
 	"github.com/ploycloud/ploy-server-cli/src/common"
 	"github.com/ploycloud/ploy-server-cli/src/docker"
@@ -26,22 +24,6 @@ var SitesCmd = &cobra.Command{
 }
 
 var logBasePath = "/var/log"
-
-var checkPloyUser = func() bool {
-	currentUser, err := user.Current()
-	if err != nil {
-		return false
-	}
-
-	// Check if user is ploy or running with sudo as ploy
-	if currentUser.Username == "ploy" {
-		return true
-	}
-
-	// Check if running with sudo
-	sudoUser := os.Getenv("SUDO_USER")
-	return sudoUser == "ploy"
-}
 
 var execSudo = func(name string, arg ...string) *exec.Cmd {
 	// Add -n flag to prevent password prompt
@@ -533,11 +515,6 @@ func setupNginxProxy(webhook string) error {
 var nginxBasePath = "/etc/nginx"
 
 func createNginxConfig(domain string, webhook string) error {
-	// Check if running as ploy user
-	if !checkPloyUser() {
-		return fmt.Errorf("this command must be run as the 'ploy' user")
-	}
-
 	sendWebhook(webhook, "Creating nginx configuration...")
 
 	// Create container name based on domain

--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-const CurrentCliVersion = "0.5.6"
+const CurrentCliVersion = "0.5.7"
 
 var (
 	HomeDir       = os.Getenv("HOME")


### PR DESCRIPTION
This pull request focuses on refactoring the `sites.go` file by removing the `checkPloyUser` function and its related code, and updating tests accordingly. Additionally, it includes a minor version bump for the CLI.

### Codebase simplification:

* Removed the `checkPloyUser` function and its usage in `src/commands/sites.go`, as it is no longer necessary. [[1]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdL30-L45) [[2]](diffhunk://#diff-f67aed92a1d9ba598a07b54d3dc9c90cc763740f5b5dd34facfeecd407da86fdL536-L540)
* Updated tests in `src/commands/sites_test.go` to remove references to `checkPloyUser` and related test cases. [[1]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L80-L84) [[2]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L288-L291) [[3]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L308-R306) [[4]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L346-L359)

### Version update:

* Bumped the CLI version from `0.5.6` to `0.5.7` in `src/common/constants.go`.