### PR TITLE
Fix/site nginx permission

### DIFF
--- a/src/commands/sites.go
+++ b/src/commands/sites.go
@@ -544,31 +544,65 @@ func createNginxConfig(domain string, webhook string) error {
 
 	// Create nginx sites directory if it doesn't exist
 	nginxSitesDir := filepath.Join(nginxBasePath, "sites-available")
-	if err := os.MkdirAll(nginxSitesDir, 0755); err != nil {
+	cmd := execSudo("mkdir", "-p", nginxSitesDir)
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to create nginx sites directory: %v", err)
 	}
 
-	// Write nginx configuration
+	// Write nginx configuration using a temporary file
+	tempFile, err := os.CreateTemp("", "nginx-conf-")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	if _, err := tempFile.WriteString(configContent); err != nil {
+		return fmt.Errorf("failed to write to temporary file: %v", err)
+	}
+	tempFile.Close()
+
+	// Move the temporary file to the nginx sites-available directory using sudo
 	configPath := filepath.Join(nginxSitesDir, domain+".conf")
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
-		return fmt.Errorf("failed to write nginx configuration: %v", err)
+	cmd = execSudo("mv", tempFile.Name(), configPath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to move nginx configuration: %v", err)
 	}
 
-	// Create symlink in sites-enabled
+	// Set proper permissions
+	cmd = execSudo("chown", "root:root", configPath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set nginx configuration ownership: %v", err)
+	}
+
+	cmd = execSudo("chmod", "644", configPath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to set nginx configuration permissions: %v", err)
+	}
+
+	// Create sites-enabled directory if it doesn't exist
 	nginxEnabledDir := filepath.Join(nginxBasePath, "sites-enabled")
-	if err := os.MkdirAll(nginxEnabledDir, 0755); err != nil {
+	cmd = execSudo("mkdir", "-p", nginxEnabledDir)
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to create nginx enabled directory: %v", err)
 	}
 
+	// Create symlink in sites-enabled using sudo
 	enabledPath := filepath.Join(nginxEnabledDir, domain+".conf")
-	if err := os.Symlink(configPath, enabledPath); err != nil && !os.IsExist(err) {
+	// Remove existing symlink if it exists
+	cmd = execSudo("rm", "-f", enabledPath)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to remove existing symlink: %v", err)
+	}
+
+	cmd = execSudo("ln", "-s", configPath, enabledPath)
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to enable nginx configuration: %v", err)
 	}
 
 	// Skip nginx reload in test environment
 	if os.Getenv("PLOY_TEST_ENV") != "true" {
 		// Reload nginx using sudo
-		cmd := execSudo("systemctl", "reload", "nginx")
+		cmd = execSudo("systemctl", "reload", "nginx")
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("failed to reload nginx: %v", err)
 		}

--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-const CurrentCliVersion = "0.5.7"
+const CurrentCliVersion = "0.5.8"
 
 var (
 	HomeDir       = os.Getenv("HOME")


### PR DESCRIPTION
This pull request includes significant updates to the Nginx configuration process in `src/commands/sites.go` and the corresponding tests in `src/commands/sites_test.go`. The primary changes involve switching to the use of sudo for file operations and enhancing the test suite to mock these operations more effectively.

### Nginx Configuration Updates:
* Replaced direct file operations with sudo commands for creating directories, writing configuration files, and setting permissions in `createNginxConfig` function.

### Test Suite Enhancements:
* Introduced a new `mockExecSudo` function to simulate sudo operations in tests, ensuring more realistic test scenarios.
* Updated `TestCreateNginxConfig` to use the new `mockExecSudo` function and added necessary environment setup and cleanup steps. [[1]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15R401-R408) [[2]](diffhunk://#diff-d318b46459d81df2b749e6acb051c1621f4c15f1de6b50d81f2e864f7156fb15L292-L342)
* Included a new import for the `time` package to handle delays in file operations during tests.

### Version Update:
* Updated the CLI version from `0.5.7` to `0.5.8` in `src/common/constants.go`.